### PR TITLE
PR for Issue #171 Old Circle Group Photos aren't deleted

### DIFF
--- a/project/circles/views.py
+++ b/project/circles/views.py
@@ -167,6 +167,15 @@ class CircleUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
         return form
 
+    def form_valid(self,form):
+        """Used to delete old photos and thumbnails"""
+        circle = Circle.objects.get(id=self.kwargs["pk"])
+        circle.photo.delete()
+
+        circle = form.save()
+
+        return HttpResponseRedirect(circle.get_absolute_url())
+
 
 def join_as_companion(request, circle_id):
     if request.user.is_authenticated:

--- a/project/circles/views.py
+++ b/project/circles/views.py
@@ -167,7 +167,7 @@ class CircleUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
 
         return form
 
-    def form_valid(self,form):
+    def form_valid(self, form):
         """Used to delete old photos and thumbnails"""
         circle = Circle.objects.get(id=self.kwargs["pk"])
         circle.photo.delete()


### PR DESCRIPTION
Closes #171 Old Circle Group Photos aren't deleted

This seems to fix the problem, the old photos are deleted before the new ones are saved to the Circle model.

This is my first time working within the Django framework, lmn if there are any things I can do to make this more robust !!

Thanks !! 